### PR TITLE
Update BugsnagAndroidDependencies.xml with a proper maven repository

### DIFF
--- a/Editor/BugsnagAndroidDependencies.xml
+++ b/Editor/BugsnagAndroidDependencies.xml
@@ -1,7 +1,7 @@
 <dependencies>
 	<androidPackages>
 		<repositories>
-			<repository>https://mvnrepository.com/artifact/org.jetbrains.kotlin/kotlin-stdlib</repository>
+			<repository>https://maven.google.com</repository>
 		</repositories>
 		<androidPackage spec="org.jetbrains.kotlin:kotlin-stdlib:1.4.32"></androidPackage>
 	</androidPackages>


### PR DESCRIPTION
The included repository address is clearly invalid. I've switched it to use google's repository. As it is the existing (incorrect) repository does not resolve packages correctly at build time and causes build failures.